### PR TITLE
Add casting for unique fields to make criteria

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -172,11 +172,13 @@ class Manager extends EventEmitter {
                 record = _makeDefaultAttributes(Model, record);
 
                 let identityFields = options.identityFields.concat();
-                identityFields =_getIdentityFields(Model, record, identityFields);
+                identityFields = _getIdentityFields(Model, record, identityFields);
 
                 let criteria = {};
                 identityFields.map((field) => {
-                    if (record[field]) criteria[field] = record[field];
+                    if (record[field]) {
+                        criteria[field] = _castField(Model, record, field);
+                    }
                 });
 
                 /*
@@ -210,7 +212,7 @@ class Manager extends EventEmitter {
                         '%j',
                     ].join('\n');
 
-                    _logger.error(errorMessage, identity, method, err.message, record);
+                    _logger.error(errorMessage, identity, method, err.message && err.message.toString(), record);
 
                     errors.push(err);
                     return iterate(records, options, output, errors);
@@ -288,6 +290,15 @@ function _get(defaultsTo) {
     return defaultsTo;
 }
 
+/**
+ * Get the fields from a model attributes that we will use
+ * to make our query's criteria.
+ *
+ * @param       {Object} Model               Waterline collection
+ * @param       {Object} record              Instance attributes
+ * @param       {Array}  [identityFields=[]] Default fields
+ * @return      {Array}                     Complete list of identity fields
+ */
 function _getIdentityFields(Model, record, identityFields=[]) {
 
     /*
@@ -307,9 +318,31 @@ function _getIdentityFields(Model, record, identityFields=[]) {
     Object.keys(schema).map((key) => {
         definition = schema[key];
         if(definition.unique) {
-            identityFields.push(key);
+            if(!identityFields.includeds(key)){
+                identityFields.push(key);
+            }
         }
     });
 
     return identityFields;
+}
+
+/**
+ * If we pass an ID as a number but the schema
+ * has id defined as text/string we will fail
+ * to match the record. This is a quick fix.
+ *
+ * @param       {Object} Model               Waterline collection
+ * @param       {Object} record              Instance attributes
+ * @return      {Mixed}        Value after casting
+ */
+function _castField(Model, record, field) {
+    let value = record[field];
+    let type = Model.attributes[field].type;
+
+    if(type === 'text' || type === 'string') {
+        value = '' + value;
+    }
+
+    return value;
 }


### PR DESCRIPTION
This closes #3 by casting fields using the model definition. Currently we are only going from number to string, but we should probably also do string -> number.