### PR TITLE
fix 5 by making criteria use OR query

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -173,11 +173,13 @@ class Manager extends EventEmitter {
                 record = _makeDefaultAttributes(Model, record);
 
                 /*
-                 * Currnetly we are retrieving all identity fields
+                 * Currently we are retrieving all identity fields
                  * and querying multiple keys, e.g.:
                  * {id:<v>, uuid:<v>, email: <v>}
+                 *
                  * Thight might not be effective and also it
                  * might not what we want.
+                 *
                  * Since using ID's can be problematic due to
                  * casting (any field for that matter) we might
                  * want to have more control in a case by case
@@ -186,10 +188,21 @@ class Manager extends EventEmitter {
                 let identityFields = options.identityFields.concat();
                 identityFields = options.getIdentityFields(Model, record, identityFields);
 
-                let criteria = {};
+                /*
+                 * A model's identityFields are all
+                 * unique attributes. If we are updating
+                 * a record, we might have changed one of
+                 * those before- e.g. email.
+                 * We use an `or` query to get around
+                 * this.
+                 */
+                let qr;
+                let criteria = { or: [] };
                 identityFields.map((field) => {
                     if (record[field]) {
-                        criteria[field] = _castField(Model, record, field);
+                        qr = {};
+                        qr[field] = _castField(Model, record, field);
+                        criteria.or.push(qr);
                     }
                 });
 


### PR DESCRIPTION
This closes #5 by building the `criteria` object as an `or` query.