### PR TITLE
fix #12: refactored importing flag to track all entities being imported

### DIFF
--- a/lib/commands/data.sync.js
+++ b/lib/commands/data.sync.js
@@ -37,10 +37,10 @@ module.exports = function dataSync(event) {
         if (errors && errors.length) {
             _logger.error('DataManager.importFileAsModels returned with %s error(s).', errors.length);
             return errors.map(err => _logger.error(err.message));
-        } else {
-            _logger.info('sync completed for entity %s', event.entity);
-            _logger.info(JSON.stringify(records, null, 4));
         }
+
+        _logger.info('sync completed for entity %s', event.entity);
+        _logger.info(JSON.stringify(records, null, 4));
 
         //TODO: we should clean up after copy. Should it be handled by datamanager?!
         if (moveAfterDone) {

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -133,6 +133,31 @@ class Manager extends EventEmitter {
         });
     }
 
+    /**
+     * Returns a list of identities for the Models
+     * currently being imported.
+     * @returns {Array}
+     */
+    currentlyBeingImported() {
+        return Object.keys(this._importingEntities).reduce((acc, key) => {
+            if (this._importingEntities[key]) acc.push(key);
+            return acc;
+        }, []);
+    }
+
+    /**
+     * Returns true if we are currently importing a model.
+     * @returns {Boolean}
+     */
+    get importing() {
+        return !!Object.values(this._importingEntities).find(e => e === true);
+    }
+
+    _importingEntity(identity, importing = true) {
+        if (!this._importingEntities) this._importingEntities = {};
+        this._importingEntities[identity] = importing;
+    }
+
     _importModel(identity, items, options = {}) {
         options = extend({}, this.importOptions, options);
 
@@ -144,7 +169,9 @@ class Manager extends EventEmitter {
         let self = this;
         let _logger = this.logger;
 
-        this.importing = true;
+        //A simple boolean flag is not enough, we want to manage 
+        //multiple entities bieng imported at the same time.
+        this._importingEntity(identity);
 
         return this.modelProvider(identity).then(Model => {
             if (!Model) return Promise.reject(new Error('Model not found'));
@@ -160,6 +187,7 @@ class Manager extends EventEmitter {
                     if (errors && errors.length) {
                         self.addErrors(identity, errors);
                     }
+                    self._importingEntity(identity, false);
                     return Promise.resolve(output);
                 }
 
@@ -260,7 +288,6 @@ class Manager extends EventEmitter {
                 return Model.destroy({}).then(_ => iterate(items, options));
             } else return iterate(items, options);
         }).then(records => {
-            this.importing = false;
             return records;
         });
     }


### PR DESCRIPTION
This closed #12 by adding a new `get importing` implementation. We are not tracking all different entities being imported.
We also added a method to return a list of all the entities being imported. We kept the `importing` flag mostly for backwards compat.