### PR TITLE
fix #16 ensure _importingEntities is created before we access it

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -44,6 +44,7 @@ class Manager extends EventEmitter {
     init(options) {
         this._parsers = {};
         this._exporters = {};
+        this._importingEntities = {};
 
         new CSVParser(this);
         new CSVExporter(this);
@@ -268,7 +269,7 @@ class Manager extends EventEmitter {
                     _logger.error('ERROR message %j', err.message);
                     _logger.error('ERROR message %j', err);
                     _logger.info('Query was:');
-                    
+
                     _logger.info('%s.%s(%j, %j)', identity, updateStrategy, criteria, record);
 
                     let errorMessage = [


### PR DESCRIPTION
This closes #16 by ensuring we check `_importingEntities` is created before we try to access it.