### PR TITLE
Add delay to import command

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -13,6 +13,27 @@ const JSONExporter = require('./exporters/json');
 
 const DEFAULTS = {
     autoinitialize: true,
+    /**
+     * We can introduce a cool down period
+     * after we have imported a number X of 
+     * items. Every time we reach this buffer
+     * counter we trigger a delay of
+     * `delayAfterItemBatch` milliseconds.
+     */
+    numberOfItemsBeforeDelay: -1,
+    /**
+     * Number in milliseconds that we would
+     * wait before resuming our importing of
+     * items.
+     * Every X items wait `delayAfterItemBatch`
+     * before resuming importing.
+     */
+    delayAfterItemBatch: 1000,
+    /**
+     * Number in milliseconds that we wait
+     * between each individual item we import.
+     */
+    delayBetweenItems: -1,
     importOptions: {
         truncate: false,
         identityFields: ['id', 'uuid'],
@@ -181,7 +202,7 @@ class Manager extends EventEmitter {
 
             let method = options.truncate ? 'create' : options.updateMethod;
 
-            function iterate(records, options, output = [], errors = []) {
+            async function iterate(records, options, output = [], errors = []) {
                 let record = records.pop();
 
                 if (!record) {
@@ -260,6 +281,22 @@ class Manager extends EventEmitter {
                     }
                 }
 
+                /**
+                 * If we have a cool period after importing X 
+                 * items do delay
+                 */
+                if (_itemTriggersBatchDelay(options, output.length)) {
+                    await delay(options.delayAfterItemBatch);
+                }
+
+                /**
+                 * We can introduce a wait period between each
+                 * individual.
+                 */
+                if (options.delayBetweenItems > 0) {
+                    await delay(options.delayBetweenItems);
+                }
+
                 let args = o.truncate ? [record] : [criteria, record];
 
                 return Model[updateStrategy].apply(Model, args).then(record => {
@@ -325,6 +362,7 @@ class Manager extends EventEmitter {
         this.logger.info('filename:', filename);
         return this.exportModels(identity, query, type, options).then(output => {
             return new Promise((resolve, reject) => {
+                //TODO: Maybe use a createWriteStream?
                 fs.writeFile(filename, output, options.fs || 'utf8', function(err) {
                     if (err) reject(err);
                     else resolve(filename);
@@ -357,6 +395,17 @@ class Manager extends EventEmitter {
 
 module.exports = Manager;
 
+async function delay(t = 100) {
+    return new Promise((resolve) => {
+        setTimeout(resolve, t);
+    });
+}
+
+function _itemTriggersBatchDelay(options, itemCount = 0) {
+    if (typeof options.numberOfItemsBeforeDelay !== 'number') return false;
+    if (options.numberOfItemsBeforeDelay === -1) return false;
+    return (options.numberOfItemsBeforeDelay % itemCount) === 0;
+}
 
 function _emptyCriteria(criteria = {}) {
     return Object.keys(criteria).length === 0;

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -198,6 +198,7 @@ class Manager extends EventEmitter {
         return this.modelProvider(identity).then(Model => {
             if (!Model) return Promise.reject(new Error('Model not found'));
 
+            //TODO: Abstract to getModelMetadata(Model)
             let attributes = Object.keys(Model._attributes);
 
             let method = options.truncate ? 'create' : options.updateMethod;
@@ -401,7 +402,7 @@ async function delay(t = 100) {
     });
 }
 
-function _itemTriggersBatchDelay(options, itemCount = 0) {
+function _itemTriggersBatchDelay(options = {}, itemCount = 0) {
     if (typeof options.numberOfItemsBeforeDelay !== 'number') return false;
     if (options.numberOfItemsBeforeDelay === -1) return false;
     return (options.numberOfItemsBeforeDelay % itemCount) === 0;


### PR DESCRIPTION
This closes #20 by adding a mechanism to add a delay between individual imports and/or after importing a given number of items:

* `numberOfItemsBeforeDelay`: We can introduce a cool down period after we have imported a number X of items. Every time we reach this buffer counter we trigger a delay of `delayAfterItemBatch` milliseconds.
* `delayAfterItemBatch`: Number in milliseconds that we would wait before resuming our importing of items. Every X items wait `delayAfterItemBatch` before resuming importing.
* `delayBetweenItems`: Number in milliseconds that we wait between each individual item we import.