### PR TITLE
fix: use context from event

### DIFF
--- a/lib/commands/data.sync.js
+++ b/lib/commands/data.sync.js
@@ -9,7 +9,7 @@ const path = require('path');
  * meaning this === app.
  */
 module.exports = function dataSync(event) {
-    const context = this;
+    const context = event.context;
     const _logger = context.getLogger('data-sync');
 
     if (!event.entity) {


### PR DESCRIPTION
This closes issue #24 by updating how we retrieve the context in sync command.