### PR TITLE
[Close #26] Fix `buildCriteria`

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -197,14 +197,11 @@ class Manager extends EventEmitter {
         let _logger = this.logger;
 
         //A simple boolean flag is not enough, we want to manage
-        //multiple entities bieng imported at the same time.
+        //multiple entities being imported at the same time.
         this._importingEntity(identity);
 
         return this.modelProvider(identity).then(Model => {
             if (!Model) return Promise.reject(new Error('Model not found'));
-
-            //TODO: Abstract to getModelMetadata(Model)
-            let attributes = Object.keys(Model._attributes);
 
             let method = options.truncate ? 'create' : options.updateMethod;
 
@@ -229,7 +226,7 @@ class Manager extends EventEmitter {
                  * Call all defined `defaultsTo` that
                  * are not present in our record.
                  * This is good so we get closer
-                 * behaviour to `Model.create`.
+                 * behavior to `Model.create`.
                  * Also, if some of those fields are
                  * unique then we ensure we can do
                  * a `updateOrCreate`.
@@ -241,7 +238,7 @@ class Manager extends EventEmitter {
                  * and querying multiple keys, e.g.:
                  * {id:<v>, uuid:<v>, email: <v>}
                  *
-                 * Thight might not be effective and also it
+                 * This might not be effective and also it
                  * might not be what we want.
                  *
                  * Since using ID's can be problematic due to
@@ -260,7 +257,7 @@ class Manager extends EventEmitter {
                  * We use an `or` query to get around
                  * this.
                  */
-                let criteria = self.buildCrietria(Model, record, identityFields);
+                let criteria = self.buildCriteria(Model, record, identityFields);
 
                 /*
                  * We need to have a way to perform a
@@ -268,7 +265,7 @@ class Manager extends EventEmitter {
                  */
                 if (_emptyCriteria(criteria)) {
                     _logger.warn('We dont have a criteria...');
-                    _logger.warn('%j', attributes);
+                    _logger.warn('%j', Object.keys(Model.attributes));
                     _logger.warn('Model keys: %j', Object.keys(Model));
                     //TODO: Not sure if this is the best way to go along?
                     if (o.truncate) {
@@ -282,7 +279,7 @@ class Manager extends EventEmitter {
                  * items then we do delay.
                  */
                 if (_itemTriggersBatchDelay(options, output.length)) {
-                    _logger.info('Colling off period, waiting for ', options.delayAfterItemBatch);
+                    _logger.info('Cooling off period, waiting for ', options.delayAfterItemBatch);
                     await delay(options.delayAfterItemBatch);
                 }
 
@@ -335,8 +332,9 @@ class Manager extends EventEmitter {
                 if (typeof query.populate === 'string' || Array.isArray(query.populate)) {
                     orm.populate(query.populate);
                 } else if (typeof query.populate === 'object') {
-                    //TODO: Check we actually have name and criteria :P
-                    orm.populate(query.populate.name, query.populate.criteria);
+                    if (query.populate.name) {
+                        orm.populate(query.populate.name, query.populate.criteria);
+                    }
                 }
             }
 
@@ -385,20 +383,46 @@ class Manager extends EventEmitter {
         return items;
     }
 
-    buildCrietria(Model, record, identityFields = []) {
-        let qr;
+    buildCriteria(Model, record, identityFields = []) {
+
+        if (!identityFields || identityFields.length === 0) {
+            throw new Error('Build Criteria: need identity fields');
+        }
+
         let criteria = { or: [] };
-        identityFields.map(field => {
-            if (record[field]) {
-                qr = {};
-                qr[field] = _castField(Model, record, field);
-                criteria.or.push(qr);
+
+        const isEmpty = v => v === undefined || v === null || v === "";
+
+        const expressionFromField = field => {
+            if (Model.attributes.hasOwnProperty(field) === false) {
+                throw new Error(`Build Criteria: model has no field ${field}`);
             }
+
+            let value = _castField(Model, record, field);
+
+            if (isEmpty(value)) return undefined;
+
+            let expression = {};
+            expression[field] = value;
+
+            return expression;
+        };
+
+        if (identityFields.length === 1) {
+            return expressionFromField(identityFields[0]);
+        }
+
+        identityFields.map(field => {
+            criteria.or.push(expressionFromField(field));
         });
 
-        return qr;
-    }
+        /**
+         * Filter out invalid criteria values
+         */
+        criteria.or = criteria.or.filter(Boolean);
 
+        return criteria;
+    }
 
     wrapError(record, identity, updateStrategy, criteria, src = {}) {
         let error = new DataManagerError(src.message, identity, updateStrategy, criteria, src);
@@ -460,10 +484,10 @@ function _get(defaultsTo) {
  * @return      {Array}                     Complete list of identity fields
  */
 function _getIdentityFields(Model, record, identityFields = []) {
-    console.log('using default function to extract identity fields', identityFields);
+    console.log('using DEFAULT FUNCTION to extract identity fields', identityFields);
     /*
      * Definition holds the schema
-     * inforamtion of your model.
+     * information of your model.
      */
     let schema = Model.definition;
 
@@ -501,6 +525,11 @@ function _getIdentityFields(Model, record, identityFields = []) {
  */
 function _castField(Model, record, field) {
     let value = record[field];
+
+    if (value === null || value === undefined) {
+        return value;
+    }
+
     let type = Model.attributes[field].type;
 
     if (type === 'text' || type === 'string') {
@@ -518,5 +547,6 @@ class DataManagerError extends Error {
         this.updateStrategy = updateStrategy;
         this.criteria = criteria;
         this.source = source;
+        this.id = `error_${identity}_${Date.now().toString(36)}`;
     }
 }


### PR DESCRIPTION
This PR closes #26:

* Fix `buildCriteria` by ensuring no field expressions include `null`, `""`, or `undefined` values.
* Fix `buildCriteria` by  including all identity fields in query
* Add error id generation to `DataManagerError` constructor
